### PR TITLE
Use the file target name when building mgc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,7 @@ configure_file(magic.in magic COPYONLY)
 
 
 add_custom_command(OUTPUT magic.mgc
-COMMAND "${CMAKE_CURRENT_BINARY_DIR}/file.exe" -C -m magic
+COMMAND file -C -m magic
 DEPENDS file
 COMMENT "Compiling magic file"
 )


### PR DESCRIPTION
By using the target name, CMake guarantees
it will find the executable it built and
thus does not require that we specify the
path to the executable.

This avoids the custom command using an
alternative version of file.exe. This can
happen when driving a Visual Studio build
from cygwin and cygwin has it's own version
of file.exe.  Actually it's quite surprising
that this problem occurred a the custom
command used CMAKE_CURRENT_BINARY_DIR to
specify the full path.